### PR TITLE
Used sample data 'items' for temporary modifications instead of impor…

### DIFF
--- a/DailyTasksApp/src/App.jsx
+++ b/DailyTasksApp/src/App.jsx
@@ -32,7 +32,53 @@ function App() {
   })
   const [tasks, setTasks] = useState([])
 
+  const adjustLayout = (items) => {
+    let currentX = 0;
 
+    return items.map((item, index) => {
+      const newItem = {
+        ...item,
+        dataGrid: {
+          ...item.dataGrid,
+          x: currentX,
+        },
+      };
+
+      currentX += item.dataGrid.w;
+
+      return newItem;
+    });
+  };
+
+  const items = [
+    {
+      key: "a",
+      dataGrid: { x: 0, y: 0, w: 2, maxW: 3, h: 1 },
+      taskName: "SaturdaySaturdaySaturdaySaturdaySaturday",
+    },
+    {
+      key: "b",
+      dataGrid: { x: 0, y: 0, w: 2, maxW: 3, h: 1 },
+      taskName: "Saturday",
+    },
+    {
+      key: "c",
+      dataGrid: { x: 0, y: 4, w: 2, maxW: 3, h: 1 },
+      taskName: "Friday",
+    },
+    {
+      key: "d",
+      dataGrid: { x: 0, y: 4, w: 2, maxW: 3, h: 1 },
+      taskName: "Friday",
+    },
+    {
+      key: "e",
+      dataGrid: { x: 0, y: 0, w: 2, maxW: 3, h: 1 },
+      taskName: "Saturday",
+    },
+  ];
+
+  const adjustedItems = adjustLayout(items);
  
  useEffect(() => {
   let newArr = []
@@ -125,8 +171,10 @@ setTasks(newArr)
               preventCollision={true}
               onDrop={onDrop}
             >
-              {tasks.map((n, i) => (
-                <div key={i} data-grid={{ x: n.x, y: n.y, w: 3, maxW: 3, h: n.h }}>{n.taskName}</div>
+              {adjustedItems.map((item) => (
+                <div key={item.key} data-grid={item.dataGrid}>
+                  {item.taskName}
+                </div>
               ))}
               {/* <div key="a" data-grid={{ x: 0, y: 0, w: 2, maxW: 3, h: 1 }}>a</div>
               <div key="b" data-grid={{ x: 1, y: 4, w: 3, maxW: 3, h: 1 }}>Saturday</div>


### PR DESCRIPTION
Hi @wendy,

I've been working on addressing an issue with element positioning within the GridLayout. Specifically, when one element is rendered after another with the exact coordinates, it unintentionally shifts below the original element. This results in a displacement even when specific coordinates are given.

To tackle this, I created dummy items data and implemented an adjustLayout function. This function automatically adjusts the data-grid property for each element, ensuring they're positioned as expected. Consequently, elements with the same coordinates now appear side by side on the same day rather than being displaced to different days.

The next step involves aligning the structure of the existing JSON file with that of the items dummy data. This should ensure that elements with only one day specified in days are displayed correctly.

I intended to finalize these adjustments and submit a PR by now, but due to the complexity and time required for these modifications, I'm currently sharing this update for your review.

Looking forward to your feedback and any further suggestions you may have.